### PR TITLE
v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # FeedReader Changelog
 
+## 2.0.1 - 2025-04-08
+
+- Fixed: Added a new catch Guzzle exception, resolves issue #4, prevents site-breaking errors when feeds are unavailable. Thanks to @smartpill for reporting this.
+
 ## 2.0.0 - 2024-04-22
 
 - Updated: Added support for Craft 5.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "dodecastudio/craft-feedreader",
   "description": "A simple plugin to load and display RSS and Atom feeds in Craft CMS templates.",
   "type": "craft-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "proprietary",
   "keywords": [
     "craft",

--- a/src/vendor/feeds/Feeds.php
+++ b/src/vendor/feeds/Feeds.php
@@ -104,6 +104,9 @@ class Feeds extends Component
         } catch (RuntimeException $e) {
             Craft::warning('There was a problem parsing the feed: ' . $e->getMessage(), __METHOD__);
             return [];
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            Craft::warning('There was a Guzzle HTTP error: ' . $e->getMessage(), __METHOD__);
+            return [];
         }
 
         $timezone = new \DateTimeZone(Craft::$app->getTimeZone());


### PR DESCRIPTION
- Fixed: Added a new catch Guzzle exception, resolves issue #4, prevents site-breaking errors when feeds are unavailable. Thanks to @smartpill for reporting this.